### PR TITLE
Fix: Wrong expiry date check + domain without info

### DIFF
--- a/whois_test.go
+++ b/whois_test.go
@@ -44,7 +44,7 @@ func TestClient(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			domain:  "name.black",
+			domain:  "nic.black", //name.black is restricted, so we'll use this instead
 			wantErr: false,
 		},
 		{
@@ -52,7 +52,7 @@ func TestClient(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			domain:  "google.com.br", // name.com.br is handled weirdly by whois.registro.br, so we'll use this instead
+			domain:  "google.com.br", //name.com.br is restricted, so we'll use this instead
 			wantErr: false,
 		},
 		{
@@ -92,7 +92,7 @@ func TestClient(t *testing.T) {
 				if err != nil {
 					t.Error("expected no error, got", err.Error())
 				}
-				if response.ExpirationDate.Unix() == 0 {
+				if response.ExpirationDate.IsZero() {
 					t.Errorf("expected to have an expiry date")
 				}
 				if len(response.NameServers) == 0 {


### PR DESCRIPTION
## Summary
Idk if there is a issue about this.
When I tried to solve [this issue](https://github.com/TwiN/gatus/issues/504), I saw that maybe the PR #7 that tried to fix .br domains, was accepted even though it didn't work.

So I figure out that the problem is in the expiry date check, which does not check correctly when the variable was only initialized (in this case has a value less than 0).

## Pay attention
This PR as it is, because how .br and .ua domains is trying to get expiry date. So maybe it's better to approve PR #8.

## Checklist
- [x] Tested and/or added tests to validate that the changes work as intended, if applicable.
- [ ] Updated documentation in `README.md`, if applicable.
