### PR TITLE
fix: Make sure domains with .cn TLD work as intended

### DIFF
--- a/whois.go
+++ b/whois.go
@@ -155,6 +155,8 @@ func (c *Client) QueryAndParse(domain string) (*Response, error) {
 				switch {
 				case strings.HasSuffix(domain, ".br"):
 					response.ExpirationDate, _ = time.Parse("20060102", strings.ToUpper(value))
+				case strings.HasSuffix(domain, ".cn"):
+					response.ExpirationDate, _ = time.Parse("2006-01-02 15:04:05", strings.ToUpper(value))
 				default:
 					response.ExpirationDate, _ = time.Parse(time.RFC3339, strings.ToUpper(value))
 				}

--- a/whois_test.go
+++ b/whois_test.go
@@ -48,6 +48,10 @@ func TestClient(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			domain:  "name.cn",
+			wantErr: false,
+		},
+		{
 			domain:  "name.de",
 			wantErr: true,
 		},
@@ -92,8 +96,8 @@ func TestClient(t *testing.T) {
 				if err != nil {
 					t.Error("expected no error, got", err.Error())
 				}
-				if response.ExpirationDate.Unix() == 0 {
-					t.Errorf("expected to have an expiry date")
+				if response.ExpirationDate.Unix() <= 0 {
+					t.Error("expected to have a valid expiry date, got", response.ExpirationDate.Unix())
 				}
 				if len(response.NameServers) == 0 {
 					t.Errorf("expected to have at least one name server")


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Summary
<!-- If there's a relevant issue, you can just write the issue number below (e.g. #123) -->
This PR should fix domains with the `cn` TLD returning a negative value for expiration time 


## Checklist
<!-- Replace [ ] by [X] if you have completed the item -->
- [X] Tested and/or added tests to validate that the changes work as intended, if applicable.
- [ ] Updated documentation in `README.md`, if applicable.
