### PR TITLE
fix: Expiration Date time parsing format for .cn

### DIFF
--- a/whois.go
+++ b/whois.go
@@ -156,7 +156,7 @@ func (c *Client) QueryAndParse(domain string) (*Response, error) {
 				case strings.HasSuffix(domain, ".br"):
 					response.ExpirationDate, _ = time.Parse("20060102", strings.ToUpper(value))
 				case strings.HasSuffix(domain, ".cn"):
-					response.ExpirationDate, _ = time.Parse(time.DateTime, strings.ToUpper(value))
+					response.ExpirationDate, _ = time.Parse("2006-01-02 15:04:05", strings.ToUpper(value))
 				default:
 					response.ExpirationDate, _ = time.Parse(time.RFC3339, strings.ToUpper(value))
 				}

--- a/whois.go
+++ b/whois.go
@@ -155,6 +155,8 @@ func (c *Client) QueryAndParse(domain string) (*Response, error) {
 				switch {
 				case strings.HasSuffix(domain, ".br"):
 					response.ExpirationDate, _ = time.Parse("20060102", strings.ToUpper(value))
+				case strings.HasSuffix(domain, ".cn"):
+					response.ExpirationDate, _ = time.Parse(time.DateTime, strings.ToUpper(value))
 				default:
 					response.ExpirationDate, _ = time.Parse(time.RFC3339, strings.ToUpper(value))
 				}


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Summary
<!-- If there's a relevant issue, you can just write the issue number below (e.g. #123) -->

This PR fixes the parsing time format for domains with the `CN`.

## Checklist
<!-- Replace [ ] by [X] if you have completed the item -->
- [X] Tested and/or added tests to validate that the changes work as intended, if applicable.
- [ ] Updated documentation in `README.md`, if applicable.
