### PR TITLE
fix: Expiration Date time parsing format for .uk and .scot domains

### DIFF
--- a/whois.go
+++ b/whois.go
@@ -148,6 +148,8 @@ func (c *Client) QueryAndParse(domain string) (*Response, error) {
 				switch {
 				case strings.HasSuffix(domain, ".co.ua"), strings.HasSuffix(domain, ".pp.ua"):
 					response.ExpirationDate, _ = time.Parse("02-Jan-2006 15:04:05 MST", strings.ToUpper(value))
+				case strings.HasSuffix(domain, ".uk"):
+					response.ExpirationDate, _ = time.Parse("02-Jan-2006", strings.ToUpper(value))
 				default:
 					response.ExpirationDate, _ = time.Parse(time.RFC3339, strings.ToUpper(value))
 				}

--- a/whois.go
+++ b/whois.go
@@ -47,6 +47,7 @@ func (c *Client) WithReferralCache(enabled bool) *Client {
 			"org":   "whois.publicinterestregistry.org",
 			"red":   "whois.nic.red",
 			"sh":    "whois.nic.sh",
+			"uk":    "whois.nic.uk",
 		}
 	}
 	return c

--- a/whois.go
+++ b/whois.go
@@ -150,6 +150,10 @@ func (c *Client) QueryAndParse(domain string) (*Response, error) {
 					response.ExpirationDate, _ = time.Parse("02-Jan-2006 15:04:05 MST", strings.ToUpper(value))
 				case strings.HasSuffix(domain, ".uk"):
 					response.ExpirationDate, _ = time.Parse("02-Jan-2006", strings.ToUpper(value))
+				case strings.HasSuffix(domain, ".scot"):
+					if !strings.Contains(key, "registrar") {
+						response.ExpirationDate, _ = time.Parse(time.RFC3339, strings.ToUpper(value))
+					}
 				default:
 					response.ExpirationDate, _ = time.Parse(time.RFC3339, strings.ToUpper(value))
 				}

--- a/whois_test.go
+++ b/whois_test.go
@@ -75,6 +75,10 @@ func TestClient(t *testing.T) {
 			domain:  "name.uk",
 			wantErr: false,
 		},
+		{
+			domain:  "dot.scot", // name.scot not registered
+			wantErr: false,
+		},
 	}
 	client := NewClient().WithReferralCache(true)
 	for _, scenario := range scenarios {

--- a/whois_test.go
+++ b/whois_test.go
@@ -67,6 +67,14 @@ func TestClient(t *testing.T) {
 			domain:  "name.pp.ua",
 			wantErr: false,
 		},
+		{
+			domain:  "name.co.uk",
+			wantErr: false,
+		},
+		{
+			domain:  "name.uk",
+			wantErr: false,
+		},
 	}
 	client := NewClient().WithReferralCache(true)
 	for _, scenario := range scenarios {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Summary
<!-- If there's a relevant issue, you can just write the issue number below (e.g. #123) -->

Hey - I've been trying out gatus over the last couple of days (really enjoying it so far!), and ran into issues with the expiry date check for *.uk and .scot domains.

For *.uk domains, it was just a case of adding an extra case for `02-Jan-2006`. I've also added an entry to the referral cache for `whois.nic.uk`.

For .scot domains, it was a bit of a weird one. It _should_ be handled by the default case, but the response from `whois.nic.scot` contains a blank `Registrar Registration Expiration Date:` line that also matches the conditions for the parse function, so repeats the loop and overwrites the correct result:

```
Registry Expiry Date: 2024-06-09T12:13:29.319Z
Registrar Registration Expiration Date: 
```

I've added a new case for .scot to skip if the string contains "registrar", but depending on the server `whois.nic.scot` is running, the issue could conceivably happen with other domains. I checked some other domains and their whois responses contained the field, so I figured it was worth limiting to just .scot.

## Checklist
<!-- Replace [ ] by [X] if you have completed the item -->
- [X] Tested and/or added tests to validate that the changes work as intended, if applicable.
- [ ] Updated documentation in `README.md`, if applicable.
