### PR TITLE
fix: Make sure domains with .im TLD work as intended

### DIFF
--- a/whois.go
+++ b/whois.go
@@ -151,6 +151,8 @@ func (c *Client) QueryAndParse(domain string) (*Response, error) {
 					response.ExpirationDate, _ = time.Parse("02-Jan-2006 15:04:05 MST", strings.ToUpper(value))
 				case strings.HasSuffix(domain, ".uk"):
 					response.ExpirationDate, _ = time.Parse("02-Jan-2006", strings.ToUpper(value))
+				case strings.HasSuffix(domain, ".im"):
+					response.ExpirationDate, _ = time.Parse("02/01/2006 15:04:05", strings.ToUpper(value))
 				case strings.HasSuffix(domain, ".scot"):
 					if !strings.Contains(key, "registrar") {
 						response.ExpirationDate, _ = time.Parse(time.RFC3339, strings.ToUpper(value))

--- a/whois_test.go
+++ b/whois_test.go
@@ -72,6 +72,10 @@ func TestClient(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			domain:  "name.im",
+			wantErr: false,
+		},
+		{
 			domain:  "name.uk",
 			wantErr: false,
 		},
@@ -106,16 +110,16 @@ func TestClient(t *testing.T) {
 			}
 			if !scenario.wantErr {
 				if err != nil {
-					t.Error("expected no error, got", err.Error())
+					t.Error("expected no error, got", err.Error(), "for domain", scenario.domain)
 				}
 				if response.ExpirationDate.Unix() <= 0 {
-					t.Error("expected to have a valid expiry date, got", response.ExpirationDate.Unix())
+					t.Error("expected to have a valid expiry date, got", response.ExpirationDate.Unix(), "for domain", scenario.domain)
 				}
 				if len(response.NameServers) == 0 {
-					t.Errorf("expected to have at least one name server")
+					t.Errorf("expected to have at least one name server for domain %s", scenario.domain)
 				}
-				if len(response.DomainStatuses) == 0 {
-					t.Errorf("expected to have at least one domain status")
+				if len(response.DomainStatuses) == 0 && !strings.HasSuffix(scenario.domain, ".im") {
+					t.Errorf("expected to have at least one domain status for domain %s", scenario.domain)
 				}
 			}
 		})


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Summary
This PR should fix domains with the im TLD returning a negative value for expiration time

cc: TwiN/gatus#548

Note: .im domains does not have statuses, therefore added extra check in tests.

## Checklist
<!-- Replace [ ] by [X] if you have completed the item -->
- [x] Tested and/or added tests to validate that the changes work as intended, if applicable.
- [ ] Updated documentation in `README.md`, if applicable.
