### PR TITLE
Implement tracking expiration date for ru/su domains

### DIFF
--- a/whois.go
+++ b/whois.go
@@ -48,6 +48,8 @@ func (c *Client) WithReferralCache(enabled bool) *Client {
 			"red":   "whois.nic.red",
 			"sh":    "whois.nic.sh",
 			"uk":    "whois.nic.uk",
+			"ru":    "whois.nic.ru",
+			"su":    "whois.nic.su",
 		}
 	}
 	return c
@@ -170,8 +172,18 @@ func (c *Client) QueryAndParse(domain string) (*Response, error) {
 					response.ExpirationDate, _ = time.Parse(time.RFC3339, strings.ToUpper(value))
 				}
 			}
+		} else if key == "paid-till" {
+			// example for ru/su domains -> paid-till: 2024-05-26T21:00:00Z
+			if strings.HasSuffix(domain, ".ru") || strings.HasSuffix(domain, ".su") {
+				response.ExpirationDate, _ = time.Parse(time.RFC3339, strings.ToUpper(value))
+			}
 		} else if strings.Contains(key, "status") {
 			response.DomainStatuses = append(response.DomainStatuses, value)
+		} else if key == "state" {
+			// example for ru/su domains -> state: DELEGATED, VERIFIED
+			if strings.HasSuffix(domain, ".ru") || strings.HasSuffix(domain, ".su") {
+				response.DomainStatuses = strings.Split(value, ", ")
+			}
 		} else if strings.Contains(key, "name server") || strings.Contains(key, "nserver") {
 			response.NameServers = append(response.NameServers, value)
 		}

--- a/whois.go
+++ b/whois.go
@@ -48,8 +48,6 @@ func (c *Client) WithReferralCache(enabled bool) *Client {
 			"red":   "whois.nic.red",
 			"sh":    "whois.nic.sh",
 			"uk":    "whois.nic.uk",
-			"ru":    "whois.nic.ru",
-			"su":    "whois.nic.su",
 		}
 	}
 	return c

--- a/whois_test.go
+++ b/whois_test.go
@@ -83,6 +83,14 @@ func TestClient(t *testing.T) {
 			domain:  "dot.scot", // name.scot not registered
 			wantErr: false,
 		},
+		{
+			domain:  "name.ru", // expiration date in `paid-till` field
+			wantErr: false,
+		},
+		{
+			domain:  "register.su", // expiration date in `paid-till` field
+			wantErr: false,
+		},
 	}
 	client := NewClient().WithReferralCache(true)
 	for _, scenario := range scenarios {


### PR DESCRIPTION
Hello. We're transitioning from `.ru` to `.space` domains but still need to track expiration for `.ru` until the migration and all the redirects are finished.

## Summary

Implement domain expration and state tracking for `.ru` and `.su` domains. These domains use slightly different semantics described in the following doc: [link](https://tcinet.ru/documents/whois_ru_rf.pdf)

Unfortunately it's in Russian, so just navigate to page 5 where the names of all the fields are present. They don't specify which format the date field is in, but it seems to be compliant with ISO8601.



## Checklist
<!-- Replace [ ] by [X] if you have completed the item -->
- [x] Tested and/or added tests to validate that the changes work as intended, if applicable.
- [ ] Updated documentation in `README.md`, if applicable.
