### PR TITLE
fix: Support for .mx ccTLD

### DIFF
--- a/whois.go
+++ b/whois.go
@@ -12,7 +12,7 @@ const (
 	ianaWHOISServerAddress = "whois.iana.org:43"
 )
 
-var tldWithoutExpirationDate = []string{"at", "be", "ch", "co.at", "com.br", "or.at", "de", "fr", "me", "mx", "nl"}
+var tldWithoutExpirationDate = []string{"at", "be", "ch", "co.at", "com.br", "or.at", "de", "fr", "me", "nl"}
 
 type Client struct {
 	whoisServerAddress string
@@ -75,12 +75,13 @@ func (c *Client) Query(domain string) (string, error) {
 	}
 	var output string
 	var err error
-	if domainExtension == "ua" {
+	switch domainExtension {
+	case "ua", "mx":
 		if len(parts) > 2 && len(parts[len(parts)-2]) < 4 {
 			domainExtension = parts[len(parts)-2] + "." + domainExtension
 		}
 		output, err = c.query("whois."+domainExtension+":43", domain)
-	} else {
+	default:
 		output, err = c.query(c.whoisServerAddress, domainExtension)
 	}
 	if err != nil {
@@ -157,6 +158,8 @@ func (c *Client) QueryAndParse(domain string) (*Response, error) {
 					if !strings.Contains(key, "registrar") {
 						response.ExpirationDate, _ = time.Parse(time.RFC3339, strings.ToUpper(value))
 					}
+				case strings.HasSuffix(domain, ".mx"):
+					response.ExpirationDate, _ = time.Parse(time.DateOnly, strings.ToUpper(value))
 				default:
 					response.ExpirationDate, _ = time.Parse(time.RFC3339, strings.ToUpper(value))
 				}

--- a/whois_test.go
+++ b/whois_test.go
@@ -91,6 +91,10 @@ func TestClient(t *testing.T) {
 			domain:  "register.su", // expiration date in `paid-till` field
 			wantErr: false,
 		},
+		{
+			domain:  "nic.mx",
+			wantErr: false,
+		},
 	}
 	client := NewClient().WithReferralCache(true)
 	for _, scenario := range scenarios {
@@ -126,7 +130,7 @@ func TestClient(t *testing.T) {
 				if len(response.NameServers) == 0 {
 					t.Errorf("expected to have at least one name server for domain %s", scenario.domain)
 				}
-				if len(response.DomainStatuses) == 0 && !strings.HasSuffix(scenario.domain, ".im") {
+				if len(response.DomainStatuses) == 0 && !strings.HasSuffix(scenario.domain, ".im") && !strings.HasSuffix(scenario.domain, ".mx") {
 					t.Errorf("expected to have at least one domain status for domain %s", scenario.domain)
 				}
 			}


### PR DESCRIPTION
## Summary
Fixes #19 to be able to get WHOIS information from `.mx` ccTLD.

## Checklist
- [x] Tested and/or added tests to validate that the changes work as intended.

**Note:** This extension does not return any domain status, so they it was excluded in the tests.