### PR TITLE
fix: Use a more reliable WHOIS server for .mx

### DIFF
--- a/whois.go
+++ b/whois.go
@@ -48,6 +48,7 @@ func (c *Client) WithReferralCache(enabled bool) *Client {
 			"red":   "whois.nic.red",
 			"sh":    "whois.nic.sh",
 			"uk":    "whois.nic.uk",
+			"mx":    "whois.nic.mx",
 		}
 	}
 	return c
@@ -76,7 +77,7 @@ func (c *Client) Query(domain string) (string, error) {
 	var output string
 	var err error
 	switch domainExtension {
-	case "ua", "mx":
+	case "ua":
 		if len(parts) > 2 && len(parts[len(parts)-2]) < 4 {
 			domainExtension = parts[len(parts)-2] + "." + domainExtension
 		}
@@ -163,7 +164,7 @@ func (c *Client) QueryAndParse(domain string) (*Response, error) {
 				response.ExpirationDate, _ = time.Parse("20060102", strings.ToUpper(value))
 			case strings.HasSuffix(domain, ".cn"):
 				response.ExpirationDate, _ = time.Parse("2006-01-02 15:04:05", strings.ToUpper(value))
-      case strings.HasSuffix(domain, ".mx"):
+			case strings.HasSuffix(domain, ".mx"):
 				response.ExpirationDate, _ = time.Parse(time.DateOnly, strings.ToUpper(value))
 			default:
 				response.ExpirationDate, _ = time.Parse(time.RFC3339, strings.ToUpper(value))


### PR DESCRIPTION
## Summary
In #20 it added support for .MX domains, however that uses the `whois.mx` server, which sometimes, and for some ccSLD like `.org.mx`, gives time-out errors.

```shell
$ go build -o bin/whois cmd/whois/main.go
$ bin/whois [REDACTED].org.mx
dial tcp 5.161.210.2:43: i/o timeout
```
![image](https://github.com/TwiN/whois/assets/4165935/a1c4d137-67d5-4833-bb56-90124842c06c)

Replacing it with `whois.nic.mx` fixes this issue for all `*.mx` extensions.

## Checklist
- [x] Tested and/or added tests to validate that the changes work as intended, if applicable.
