### PR TITLE
Fixed domains without expiration date list

### DIFF
--- a/whois.go
+++ b/whois.go
@@ -40,7 +40,6 @@ func (c *Client) WithReferralCache(enabled bool) *Client {
 		c.referralWHOISServersCache = map[string]string{
 			"com":   "whois.verisign-grs.com",
 			"black": "whois.nic.black",
-			"dev":   "whois.nic.google",
 			"green": "whois.nic.green",
 			"io":    "whois.nic.io",
 			"net":   "whois.verisign-grs.com",
@@ -48,7 +47,7 @@ func (c *Client) WithReferralCache(enabled bool) *Client {
 			"red":   "whois.nic.red",
 			"sh":    "whois.nic.sh",
 			"uk":    "whois.nic.uk",
-			"mx":    "whois.nic.mx",
+			"mx":    "whois.mx",
 		}
 	}
 	return c
@@ -70,8 +69,8 @@ func (c *Client) Query(domain string) (string, error) {
 		return "", errors.New("domain extension " + domainExtension + " does not have a grace period.")
 	}
 	if c.isCachingReferralWHOISServers {
-		if cachedWHOISServer, ok := c.referralWHOISServersCache[domain]; ok {
-			return c.query(cachedWHOISServer, domain)
+		if cachedWHOISServer, ok := c.referralWHOISServersCache[domainExtension]; ok {
+			return c.query(cachedWHOISServer+":43", domain)
 		}
 	}
 	var output string
@@ -94,7 +93,7 @@ func (c *Client) Query(domain string) (string, error) {
 		whois := strings.TrimSpace(output[startIndex:endIndex])
 		if referOutput, err := c.query(whois+":43", domain); err == nil {
 			if c.isCachingReferralWHOISServers {
-				c.referralWHOISServersCache[domain] = whois + ":43"
+				c.referralWHOISServersCache[domainExtension] = whois
 			}
 			return referOutput, nil
 		}

--- a/whois.go
+++ b/whois.go
@@ -12,7 +12,7 @@ const (
 	ianaWHOISServerAddress = "whois.iana.org:43"
 )
 
-var tldWithoutExpirationDate = []string{"at", "be", "ch", "co.at", "com.br", "or.at", "de", "fr", "nl"}
+var tldWithoutExpirationDate = []string{"at", "be", "ch", "co.at", "de", "eu", "nl", "or.at"}
 
 type Client struct {
 	whoisServerAddress string

--- a/whois_test.go
+++ b/whois_test.go
@@ -32,10 +32,6 @@ func TestClient(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			domain:  "get.dev",
-			wantErr: false,
-		},
-		{
 			domain:  "name.red",
 			wantErr: false,
 		},
@@ -53,6 +49,10 @@ func TestClient(t *testing.T) {
 		},
 		{
 			domain:  "name.de",
+			wantErr: true,
+		},
+		{
+			domain:  "name.eu",
 			wantErr: true,
 		},
 		{


### PR DESCRIPTION
It seems I used a list 2 years ago which was compiled for domains without a grace period, which is not the same as domains without expiration date. I am very sorry for that.

This list might still be incomplete. I checked all these domains manually and removed those which have an expiration date. I also added "eu".

Ref #25 
