### PR TITLE
feat: Add .lt expiration parsing

### DIFF
--- a/whois.go
+++ b/whois.go
@@ -165,6 +165,8 @@ func (c *Client) QueryAndParse(domain string) (*Response, error) {
 				response.ExpirationDate, _ = time.Parse("2006-01-02 15:04:05", strings.ToUpper(value))
 			case strings.HasSuffix(domain, ".mx"):
 				response.ExpirationDate, _ = time.Parse(time.DateOnly, strings.ToUpper(value))
+			case strings.HasSuffix(domain, ".lt"):
+				response.ExpirationDate, _ = time.Parse(time.DateOnly, strings.ToUpper(value))
 			case strings.HasSuffix(domain, ".ro"):
 				response.ExpirationDate, _ = time.Parse(time.DateOnly, strings.ToUpper(value))
 			default:

--- a/whois_test.go
+++ b/whois_test.go
@@ -91,6 +91,10 @@ func TestClient(t *testing.T) {
 			domain:  "google.ro",
 			wantErr: false,
 		},
+		{
+			domain:  "google.lt",
+			wantErr: false,
+		},
 	}
 	client := NewClient().WithReferralCache(true)
 	for _, scenario := range scenarios {


### PR DESCRIPTION

## Summary
- Parse .lt domain expiration date from WHOIS output (YYYY-MM-DD)
- Add .lt test case

## Checklist
- [x] Tested and/or added tests to validate that the changes work as intended, if applicable.
- [ ] Updated documentation in `README.md`, if applicable.
